### PR TITLE
Always return a response code for the client to consume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stubborn-fetch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fetch wrapper with built in retry",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -12,37 +12,27 @@
     "jest": "./node_modules/.bin/jest --watch --colors",
     "lint": "node ./node_modules/.bin/eslint src/",
     "prepublish": "npm run build",
-    "test": "./node_modules/.bin/flow && ./node_modules/.bin/jest && node ./node_modules/eslint/bin/eslint.js src/ --quiet",
+    "test":
+      "./node_modules/.bin/flow && ./node_modules/.bin/jest && node ./node_modules/eslint/bin/eslint.js src/ --quiet",
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "src/**/*.js": [
-      "./node_modules/.bin/prettier --write",
-      "git add"
-    ]
+    "src/**/*.js": ["./node_modules/.bin/prettier --write", "git add"]
   },
   "pre-commit": "lint-staged",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Quiq/stubborn-fetch.git"
   },
-  "keywords": [
-    "fetch",
-    "retry"
-  ],
+  "keywords": ["fetch", "retry"],
   "author": "Quiq",
   "license": "MIT",
   "jest": {
-    "moduleDirectories": [
-      "src",
-      "node_modules"
-    ],
+    "moduleDirectories": ["src", "node_modules"],
     "testEnvironmentOptions": {
       "resources": "usable"
     },
-    "setupFiles": [
-      "./jest.setup.js"
-    ]
+    "setupFiles": ["./jest.setup.js"]
   },
   "bugs": {
     "url": "https://github.com/Quiq/stubborn-fetch/issues"
@@ -80,7 +70,5 @@
     "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-resolve": "^3.3.0"
   },
-  "files": [
-    "dist"
-  ]
+  "files": ["dist"]
 }

--- a/src/error.js
+++ b/src/error.js
@@ -29,19 +29,69 @@ export class StubbornFetchError extends ExtendableError {
   }
 }
 
+const persistResponse = (response: Response): Response =>
+  (({
+    headers: response.headers,
+    ok: response.ok,
+    redirected: response.redirected,
+    status: response.status,
+    statusText: response.statusText,
+    type: response.type,
+    url: response.url,
+    bodyUsed: response.bodyUsed,
+  }: any): Response);
+
+const generateResponseObject = (statusText: string, url: string): Response =>
+  (({
+    headers: {},
+    ok: false,
+    redirected: undefined,
+    status: 0,
+    statusText,
+    type: 'error',
+    url,
+    bodyUsed: false,
+  }: any): Response);
+
 export const ErrorFactory = {
   TIMEOUT: (url: string, request: Object) =>
-    new StubbornFetchError(StubbornFetchError.types.TIMEOUT, {url, request}),
+    new StubbornFetchError(StubbornFetchError.types.TIMEOUT, {
+      url,
+      request,
+      response: generateResponseObject(StubbornFetchError.types.TIMEOUT, url),
+    }),
   MAX_ERRORS_EXCEEDED: (url: string, request: Object, errorLimit: number) =>
-    new StubbornFetchError('Max_Errors_Exceeded', {errorLimit, url, request}),
+    new StubbornFetchError(StubbornFetchError.types.MAX_ERROS_EXCEEDED, {
+      errorLimit,
+      url,
+      request,
+      response: generateResponseObject(StubbornFetchError.types.MAX_ERROS_EXCEEDED, url),
+    }),
   NETWORK_ERROR: (url: string, request: Object, underlyingError: Error) =>
-    new StubbornFetchError('Network', {underlyingError, url, request}),
+    new StubbornFetchError(StubbornFetchError.types.NETWORK_ERROR, {
+      underlyingError,
+      url,
+      request,
+      response: generateResponseObject(StubbornFetchError.types.NETWORK_ERROR, url),
+    }),
   STUBBORN_FETCH_DISABLED: (url: string, request: Object) =>
-    new StubbornFetchError('Stubborn_Fetch_Disabled', {url, request}),
+    new StubbornFetchError(StubbornFetchError.types.STUBBORN_FETCH_DISABLED, {
+      url,
+      request,
+      response: generateResponseObject(StubbornFetchError.types.STUBBORN_FETCH_DISABLED, url),
+    }),
   HTTP_ERROR: (url: string, request: Object, response: Response) =>
-    new StubbornFetchError('HTTP', {response, url, request}),
-  RATE_LIMITED: (url: string, request: Object) =>
-    new StubbornFetchError('Rate_Limited', {url, request}),
+    new StubbornFetchError(StubbornFetchError.types.HTTP_ERROR, {
+      url,
+      request,
+      response: persistResponse(response),
+    }),
+  RATE_LIMITED: (url: string, request: Object, response: Response) =>
+    new StubbornFetchError(StubbornFetchError.types.RATE_LIMITED, {
+      url,
+      request,
+      response: persistResponse(response),
+    }),
 };
 
 export default StubbornFetchError;

--- a/src/stubbornFetch.js
+++ b/src/stubbornFetch.js
@@ -234,9 +234,10 @@ class StubbornFetchRequest {
             if (
               this.options.totalRequestTimeLimit &&
               StubbornFetchRequest.rateLimitedUntil - this.startTime >
-                this.options.totalRequestTimeLimit
+                this.options.totalRequestTimeLimit &&
+              e.data.response
             ) {
-              this.error = ErrorFactory.RATE_LIMITED(this.url, this.fetchRequest);
+              this.error = ErrorFactory.RATE_LIMITED(this.url, this.fetchRequest, e.data.response);
               this.rejectImmediately(this.error);
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,7 +1838,7 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extendable-error-class@^0.1.1:
+extendable-error-class@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/extendable-error-class/-/extendable-error-class-0.1.1.tgz#d75a3e7c23141da6ff91016a357e56e5cce0e334"
 


### PR DESCRIPTION
There were a few cases we weren't returning a response object to the client, which made it hard to determining what was happening with the errors.  These changes make it so the UI can count on having _some_ idea of what happened